### PR TITLE
fix maven repository order

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,8 @@
 
 buildscript {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.2'
@@ -15,8 +15,8 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 }
 


### PR DESCRIPTION
This project does not build without certain pre-installed dependencies. Here is what happened when I first built it:

    ./gradlew build

    ...

    FAILURE: Build failed with an exception.
    
    * What went wrong:
    A problem occurred configuring root project 'AndroidPluggableTransports'.
    > Could not resolve all files for configuration ':classpath'.
       > Could not find lint-gradle-api.jar (com.android.tools.lint:lint-gradle-api:26.1.2).
         Searched in the following locations:
             https://jcenter.bintray.com/com/android/tools/lint/lint-gradle-api/26.1.2/lint-gradle-api-26.1.2.jar

(You can reproduce this by simply clearing your gralde caches: `rm -rf ~/.gradle/caches`)

I could fix this issue by putting googles maven repository on top of the repo list.